### PR TITLE
feat: 디자인 토큰 시스템 구축 및 스토리북 토큰 스토리 추가

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -89,6 +89,22 @@
 
 UI 컴포넌트 단위 검증을 위해 Storybook을 사용합니다.
 
+## 디자인 시스템
+
+현재 저장소는 Figma MCP 결과물을 직접 당겨오는 런타임 연결은 없지만, 연동을 받아들일 수 있는 구조를 갖추도록 정리했습니다.
+
+- 디자인 토큰 레지스트리는 `src/design-system/tokens.ts`에서 관리합니다.
+- 실제 스타일 소스는 `src/index.css`의 CSS 변수이며, 앱과 Storybook이 같은 토큰을 공유합니다.
+- 공용 UI 컴포넌트는 `src/shared/components`에 두고 Storybook에서 상태별로 검증합니다.
+- 토큰 카탈로그는 `Foundations/Design Tokens` 스토리에서 확인할 수 있습니다.
+
+### Figma MCP 연결 권장 흐름
+
+1. Figma MCP 또는 디자인 토큰 export 단계에서 색상, 타이포, spacing, radius를 JSON 또는 TS 객체로 추출합니다.
+2. 그 결과물을 `src/design-system/tokens.ts` 구조에 맞게 매핑합니다.
+3. 공용 컴포넌트는 raw hex 값 대신 semantic token 또는 CSS 변수만 사용합니다.
+4. 변경 검증은 Storybook에서 먼저 하고, 이후 실제 페이지에 반영합니다.
+
 ### 실행 방법
 
 ```bash

--- a/src/design-system/tokens.ts
+++ b/src/design-system/tokens.ts
@@ -1,0 +1,106 @@
+export const designTokens = {
+  colors: {
+    primary: {
+      50: "var(--color-primary-50)",
+      100: "var(--color-primary-100)",
+      300: "var(--color-primary-300)",
+      500: "var(--color-primary-500)",
+      700: "var(--color-primary-700)",
+      900: "var(--color-primary-900)",
+    },
+    gray: {
+      0: "var(--color-gray-0)",
+      50: "var(--color-gray-50)",
+      100: "var(--color-gray-100)",
+      200: "var(--color-gray-200)",
+      400: "var(--color-gray-400)",
+      700: "var(--color-gray-700)",
+      900: "var(--color-gray-900)",
+      1000: "var(--color-gray-1000)",
+    },
+    semantic: {
+      success: "var(--color-success)",
+      warning: "var(--color-warning)",
+      error: "var(--color-error)",
+      info: "var(--color-info)",
+    },
+  },
+  typography: {
+    fontFamily: {
+      display: "var(--font-family-display)",
+      body: "var(--font-family-body)",
+    },
+    fontSize: {
+      xs: "var(--font-size-xs)",
+      sm: "var(--font-size-sm)",
+      md: "var(--font-size-md)",
+      lg: "var(--font-size-lg)",
+      xl: "var(--font-size-xl)",
+      xxl: "var(--font-size-2xl)",
+      xxxl: "var(--font-size-3xl)",
+    },
+    lineHeight: {
+      tight: "var(--line-height-tight)",
+      normal: "var(--line-height-normal)",
+      relaxed: "var(--line-height-relaxed)",
+    },
+    fontWeight: {
+      regular: "var(--font-weight-regular)",
+      medium: "var(--font-weight-medium)",
+      semibold: "var(--font-weight-semibold)",
+      bold: "var(--font-weight-bold)",
+      black: "var(--font-weight-black)",
+    },
+  },
+  spacing: {
+    1: "var(--spacing-1)",
+    2: "var(--spacing-2)",
+    3: "var(--spacing-3)",
+    4: "var(--spacing-4)",
+    5: "var(--spacing-5)",
+    6: "var(--spacing-6)",
+    8: "var(--spacing-8)",
+    10: "var(--spacing-10)",
+    12: "var(--spacing-12)",
+  },
+  radius: {
+    xs: "var(--radius-xs)",
+    sm: "var(--radius-sm)",
+    md: "var(--radius-md)",
+    lg: "var(--radius-lg)",
+    xl: "var(--radius-xl)",
+    full: "var(--radius-full)",
+  },
+  shadows: {
+    brutal: "5px 5px 0 0 var(--color-black)",
+  },
+} as const;
+
+export const semanticTokens = {
+  button: {
+    primary: {
+      background: "var(--color-primary-500)",
+      text: "var(--color-gray-1000)",
+    },
+    secondary: {
+      background: "var(--color-gray-0)",
+      text: "var(--color-gray-1000)",
+    },
+    danger: {
+      background: "var(--color-error)",
+      text: "var(--color-gray-0)",
+    },
+  },
+  surface: {
+    canvas: "var(--color-gray-50)",
+    panel: "var(--color-gray-100)",
+    inverse: "var(--color-gray-900)",
+  },
+  text: {
+    primary: "var(--color-gray-1000)",
+    secondary: "var(--color-gray-700)",
+    inverse: "var(--color-gray-0)",
+  },
+} as const;
+
+export type DesignTokens = typeof designTokens;

--- a/src/index.css
+++ b/src/index.css
@@ -2,29 +2,104 @@
 @import url("https://fonts.googleapis.com/css2?family=Black+Han+Sans&family=Lexend+Mega:wght@100..900&display=swap");
 @import "tailwindcss";
 
+:root {
+  /* Color - Primary */
+  --color-primary-50: #f6f4dc;
+  --color-primary-100: #ede9b9;
+  --color-primary-300: #d5cb6f;
+  --color-primary-500: #f8c031;
+  --color-primary-700: #8a6f14;
+  --color-primary-900: #3f3b00;
+
+  /* Color - Gray Scale */
+  --color-gray-0: #ffffff;
+  --color-gray-50: #f5f5f5;
+  --color-gray-100: #e1dec7;
+  --color-gray-200: #c5c0a5;
+  --color-gray-400: #aca788;
+  --color-gray-700: #383624;
+  --color-gray-900: #282617;
+  --color-gray-1000: #000000;
+
+  /* Color - Semantic */
+  --color-success: #16a34a;
+  --color-warning: #f59e0b;
+  --color-error: #ef4444;
+  --color-info: #0ea5e9;
+
+  /* Typography - Font Family */
+  --font-family-display: "Black Han Sans", sans-serif;
+  --font-family-body: "Lexend Mega", sans-serif;
+
+  /* Typography - Font Size */
+  --font-size-xs: 0.75rem;
+  --font-size-sm: 0.875rem;
+  --font-size-md: 1rem;
+  --font-size-lg: 1.125rem;
+  --font-size-xl: 1.25rem;
+  --font-size-2xl: 1.5rem;
+  --font-size-3xl: 1.875rem;
+
+  /* Typography - Line Height */
+  --line-height-tight: 1.2;
+  --line-height-normal: 1.5;
+  --line-height-relaxed: 1.7;
+
+  /* Typography - Weight */
+  --font-weight-regular: 400;
+  --font-weight-medium: 500;
+  --font-weight-semibold: 600;
+  --font-weight-bold: 700;
+  --font-weight-black: 900;
+
+  /* Spacing */
+  --spacing-1: 0.25rem;
+  --spacing-2: 0.5rem;
+  --spacing-3: 0.75rem;
+  --spacing-4: 1rem;
+  --spacing-5: 1.25rem;
+  --spacing-6: 1.5rem;
+  --spacing-8: 2rem;
+  --spacing-10: 2.5rem;
+  --spacing-12: 3rem;
+
+  /* Radius */
+  --radius-xs: 0.25rem;
+  --radius-sm: 0.5rem;
+  --radius-md: 0.75rem;
+  --radius-lg: 1rem;
+  --radius-xl: 1.25rem;
+  --radius-full: 9999px;
+
+  /* Radius aliases for framework mapping */
+  --token-radius-sm: var(--radius-sm);
+  --token-radius-md: var(--radius-md);
+  --token-radius-lg: var(--radius-lg);
+}
+
 @theme {
   /* Colors */
-  --color-dark-1: #383624;
-  --color-dark-2: #282617;
-  --color-primary: #3f3b00;
-  --color-accent: #f8c031;
-  --color-accent-2: #fcd256;
-  --color-panel: #e1dec7;
-  --color-bubble-other: #aca788;
-  --color-danger: #ff0000;
-  --color-white: #ffffff;
-  --color-black: #000000;
+  --color-dark-1: var(--color-gray-700);
+  --color-dark-2: var(--color-gray-900);
+  --color-primary: var(--color-primary-900);
+  --color-accent: var(--color-primary-500);
+  --color-accent-2: var(--color-primary-300);
+  --color-panel: var(--color-gray-100);
+  --color-bubble-other: var(--color-gray-400);
+  --color-danger: var(--color-error);
+  --color-white: var(--color-gray-0);
+  --color-black: var(--color-gray-1000);
 
   /* Layout */
   --box-shadow: 5px 5px var(--color-black);
   --thick-border: 0.25rem solid var(--color-black);
-  --radius-lg: 1rem;
-  --radius-md: 0.7rem;
-  --radius-sm: 0.5rem;
+  --radius-lg: var(--token-radius-lg);
+  --radius-md: var(--token-radius-md);
+  --radius-sm: var(--token-radius-sm);
 
   /* Fonts */
-  --font-black-han-sans: "Black Han Sans", sans-serif;
-  --font-Lexend-Mega: "Lexend Mega", sans-serif;
+  --font-black-han-sans: var(--font-family-display);
+  --font-Lexend-Mega: var(--font-family-body);
   --font-caprasimo: "Caprasimo", cursive;
   --font-roboto-slab: "Roboto Slab", sans-serif;
 }
@@ -35,10 +110,10 @@
 html {
   font-size: calc(10px + 0.5vw);
   font-family: var(--font-Lexend-Mega), var(--font-black-han-sans);
-  line-height: 1.5;
+  line-height: var(--line-height-normal);
   height: 100%;
   overflow: hidden;
-  color: #ebe7ef;
+  color: var(--color-gray-50);
 
   font-synthesis: none;
   text-rendering: optimizeLegibility;
@@ -97,13 +172,13 @@ a {
 }
 @layer components {
   .brutal-box {
-    border: 4px solid #000;
-    box-shadow: 5px 5px 0 0 rgba(0, 0, 0, 1);
+    border: 4px solid var(--color-black);
+    box-shadow: 5px 5px 0 0 var(--color-black);
   }
 
   .brutal-btn {
-    border: 4px solid #000;
-    box-shadow: 5px 5px 0 0 rgba(0, 0, 0, 1);
+    border: 4px solid var(--color-black);
+    box-shadow: 5px 5px 0 0 var(--color-black);
     transition: all 0.2s;
   }
 

--- a/src/shared/components/Button.stories.tsx
+++ b/src/shared/components/Button.stories.tsx
@@ -1,28 +1,20 @@
 import type { Meta, StoryObj } from "@storybook/react";
 import React from "react";
 
-type ButtonVariant = "primary" | "secondary" | "danger";
 type InteractionState = "default" | "hover" | "active";
+import { Button } from "./Button";
 
-interface StoryButtonProps {
+interface StoryButtonProps extends Omit<React.ComponentProps<typeof Button>, "children"> {
   label: string;
-  variant: ButtonVariant;
-  disabled: boolean;
   interactionState: InteractionState;
 }
 
 function StoryButton({
   label,
-  variant,
-  disabled,
   interactionState,
+  className,
+  ...props
 }: StoryButtonProps) {
-  const variantClassMap: Record<ButtonVariant, string> = {
-    primary: "bg-yellow-400 text-black",
-    secondary: "bg-white text-black",
-    danger: "bg-red-500 text-white",
-  };
-
   const interactionClassMap: Record<InteractionState, string> = {
     default: "",
     hover: "translate-x-[5px] translate-y-[5px] shadow-none",
@@ -30,13 +22,12 @@ function StoryButton({
   };
 
   return (
-    <button
-      type="button"
-      disabled={disabled}
-      className={`brutal-btn rounded-xl px-5 py-3 text-sm font-bold transition-transform ${variantClassMap[variant]} ${interactionClassMap[interactionState]} ${disabled ? "opacity-50 cursor-not-allowed" : "cursor-pointer"}`}
+    <Button
+      className={`${interactionClassMap[interactionState]} ${className ?? ""}`.trim()}
+      {...props}
     >
       {label}
-    </button>
+    </Button>
   );
 }
 
@@ -47,6 +38,7 @@ const meta = {
   args: {
     label: "Play",
     variant: "primary",
+    size: "md",
     disabled: false,
     interactionState: "default",
   },
@@ -55,6 +47,10 @@ const meta = {
     variant: {
       control: { type: "inline-radio" },
       options: ["primary", "secondary", "danger"],
+    },
+    size: {
+      control: { type: "inline-radio" },
+      options: ["sm", "md", "lg"],
     },
     disabled: { control: "boolean" },
     interactionState: {

--- a/src/shared/components/Button.tsx
+++ b/src/shared/components/Button.tsx
@@ -1,0 +1,51 @@
+import type { ButtonHTMLAttributes, ReactNode } from "react";
+
+type ButtonVariant = "primary" | "secondary" | "danger";
+type ButtonSize = "sm" | "md" | "lg";
+
+const VARIANT_STYLES: Record<ButtonVariant, string> = {
+  primary: "bg-accent text-black",
+  secondary: "bg-white text-black",
+  danger: "bg-red-500 text-white",
+};
+
+const SIZE_STYLES: Record<ButtonSize, string> = {
+  sm: "px-4 py-2 text-sm rounded-lg",
+  md: "px-5 py-3 text-sm rounded-xl",
+  lg: "px-8 py-4 text-lg rounded-2xl",
+};
+
+export interface ButtonProps extends Omit<
+  ButtonHTMLAttributes<HTMLButtonElement>,
+  "children"
+> {
+  children: ReactNode;
+  variant?: ButtonVariant;
+  size?: ButtonSize;
+}
+
+export function Button({
+  children,
+  variant = "primary",
+  size = "md",
+  className,
+  disabled,
+  type = "button",
+  ...props
+}: ButtonProps) {
+  const classes = [
+    "brutal-btn font-bold transition-transform",
+    VARIANT_STYLES[variant],
+    SIZE_STYLES[size],
+    disabled ? "cursor-not-allowed opacity-50" : "cursor-pointer",
+    className,
+  ]
+    .filter(Boolean)
+    .join(" ");
+
+  return (
+    <button type={type} disabled={disabled} className={classes} {...props}>
+      {children}
+    </button>
+  );
+}

--- a/src/shared/components/DesignTokens.stories.tsx
+++ b/src/shared/components/DesignTokens.stories.tsx
@@ -1,0 +1,132 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import React from "react";
+
+import { designTokens } from "@/design-system/tokens";
+
+function TokenSection({
+  title,
+  children,
+}: {
+  title: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <section className="w-full space-y-4 rounded-3xl border-4 border-black bg-white p-6 text-black shadow-[5px_5px_0_0_#000]">
+      <h2 className="text-2xl font-black">{title}</h2>
+      {children}
+    </section>
+  );
+}
+
+function Swatch({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="space-y-2">
+      <div
+        className="h-20 rounded-2xl border-4 border-black"
+        style={{ backgroundColor: value }}
+      />
+      <div className="text-sm font-bold">{label}</div>
+      <div className="text-xs text-gray-700">{value}</div>
+    </div>
+  );
+}
+
+function TokenCatalog() {
+  const primaryColors = Object.entries(designTokens.colors.primary);
+  const grayColors = Object.entries(designTokens.colors.gray);
+  const semanticColors = Object.entries(designTokens.colors.semantic);
+  const spacingTokens = Object.entries(designTokens.spacing);
+  const radiusTokens = Object.entries(designTokens.radius);
+
+  return (
+    <div className="w-[min(1100px,100%)] space-y-6 text-black">
+      <TokenSection title="Color Tokens">
+        <div className="grid gap-4 md:grid-cols-3">
+          <div className="space-y-4">
+            <h3 className="text-lg font-black">Primary</h3>
+            <div className="grid gap-4 sm:grid-cols-2">
+              {primaryColors.map(([token, value]) => (
+                <Swatch key={token} label={`primary.${token}`} value={value} />
+              ))}
+            </div>
+          </div>
+          <div className="space-y-4">
+            <h3 className="text-lg font-black">Gray</h3>
+            <div className="grid gap-4 sm:grid-cols-2">
+              {grayColors.map(([token, value]) => (
+                <Swatch key={token} label={`gray.${token}`} value={value} />
+              ))}
+            </div>
+          </div>
+          <div className="space-y-4">
+            <h3 className="text-lg font-black">Semantic</h3>
+            <div className="grid gap-4">
+              {semanticColors.map(([token, value]) => (
+                <Swatch key={token} label={`semantic.${token}`} value={value} />
+              ))}
+            </div>
+          </div>
+        </div>
+      </TokenSection>
+
+      <TokenSection title="Typography Tokens">
+        <div className="space-y-4">
+          <div
+            style={{ fontFamily: designTokens.typography.fontFamily.display }}
+          >
+            <div className="text-sm font-bold">display</div>
+            <div className="text-4xl">Black Han Sans Heading</div>
+          </div>
+          <div style={{ fontFamily: designTokens.typography.fontFamily.body }}>
+            <div className="text-sm font-bold">body</div>
+            <div className="text-xl">
+              Lexend Mega body copy for system labels and gameplay UI.
+            </div>
+          </div>
+        </div>
+      </TokenSection>
+
+      <TokenSection title="Spacing And Radius Tokens">
+        <div className="grid gap-6 md:grid-cols-2">
+          <div className="space-y-3">
+            <h3 className="text-lg font-black">Spacing</h3>
+            {spacingTokens.map(([token, value]) => (
+              <div key={token} className="flex items-center gap-4">
+                <div className="w-24 text-sm font-bold">spacing.{token}</div>
+                <div className="h-4 bg-black" style={{ width: value }} />
+                <div className="text-xs text-gray-700">{value}</div>
+              </div>
+            ))}
+          </div>
+          <div className="space-y-3">
+            <h3 className="text-lg font-black">Radius</h3>
+            {radiusTokens.map(([token, value]) => (
+              <div key={token} className="flex items-center gap-4">
+                <div className="w-24 text-sm font-bold">radius.{token}</div>
+                <div
+                  className="h-14 w-24 border-4 border-black bg-yellow-300"
+                  style={{ borderRadius: value }}
+                />
+                <div className="text-xs text-gray-700">{value}</div>
+              </div>
+            ))}
+          </div>
+        </div>
+      </TokenSection>
+    </div>
+  );
+}
+
+const meta = {
+  title: "Foundations/Design Tokens",
+  component: TokenCatalog,
+  tags: ["autodocs"],
+  parameters: {
+    layout: "fullscreen",
+  },
+} satisfies Meta<typeof TokenCatalog>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Catalog: Story = {};


### PR DESCRIPTION
## 변경 사항
- 피그마 매핑 기준의 디자인 토큰(color/typography/spacing/radius) 정리
- src/index.css 전역 CSS 변수 및 토큰 매핑 반영
- 재사용 가능한 Button 컴포넌트 추가
- Storybook용 DesignTokens 스토리 추가
- Button 스토리 타입 오류 수정

## 검증
- pnpm build
- pnpm build-storybook

## 참고
- 생성 산출물(storybook-static)은 커밋에서 제외